### PR TITLE
Refer pool by storage and re-run prettier

### DIFF
--- a/contracts/RewarderMock.sol
+++ b/contracts/RewarderMock.sol
@@ -42,12 +42,7 @@ contract RewarderMock is IRewarder {
         uint256 pid,
         address user,
         uint256 sushiAmount
-    )
-        external
-        view
-        override
-        returns (IERC20[] memory rewardTokens, uint256[] memory rewardAmounts)
-    {
+    ) external view override returns (IERC20[] memory rewardTokens, uint256[] memory rewardAmounts) {
         /*IERC20[] memory _rewardTokens = new IERC20[](1);
         _rewardTokens[0] = (rewardToken);
         uint256[] memory _rewardAmounts = new uint256[](1);
@@ -57,10 +52,7 @@ contract RewarderMock is IRewarder {
     }
 
     modifier onlyMCV2() {
-        require(
-            msg.sender == MASTERCHEF_V2,
-            "Only MCV2 can call this function."
-        );
+        require(msg.sender == MASTERCHEF_V2, "Only MCV2 can call this function.");
         _;
     }
 }

--- a/contracts/curves/Sigmoid.sol
+++ b/contracts/curves/Sigmoid.sol
@@ -9,14 +9,11 @@ contract Sigmoid {
     int256 constant VERTICAL_SHIFT = 0; // care must be taken not to allow negative y-values
 
     function curve(uint256 maturity) external pure returns (uint256) {
-        int256 denom = sqrt(
-            (int256(maturity) - HORIZONTAL_SHIFT)**2 + HORIZONTAL_STRETCH**2
-        );
+        int256 denom = sqrt((int256(maturity) - HORIZONTAL_SHIFT)**2 + HORIZONTAL_STRETCH**2);
 
         return
             uint256(
-                (VERTICAL_STRETCH *
-                    ((int256(maturity) - HORIZONTAL_SHIFT) + denom)) / // denom is added to place lower bound at 0
+                (VERTICAL_STRETCH * ((int256(maturity) - HORIZONTAL_SHIFT) + denom)) / // denom is added to place lower bound at 0
                     denom +
                     VERTICAL_SHIFT
             );


### PR DESCRIPTION
- rename `_totalDeposits()` to `_poolBalance()`
- refer `pool` by storage in `updatePool()` instead of copying from memory to storage and returning memory struct
- our prettier options have been updated/improved since i last worked on the repo, so a few changes have also snuck in due to running prettier on the contracts directory