### PR TITLE
Tess review 2

### DIFF
--- a/contracts/Reliquary.sol
+++ b/contracts/Reliquary.sol
@@ -469,12 +469,14 @@ contract Reliquary is Relic, Ownable, Multicall, ReentrancyGuard {
     function emergencyWithdraw(uint256 pid, uint256 positionId) public nonReentrant {
         address to = ownerOf(positionId);
         require(to == msg.sender, "you do not own this position");
+
         PositionInfo storage position = positionInfo[pid][positionId];
         uint256 amount = position.amount;
-        _updateAverageEntry(pid, amount, Kind.WITHDRAW);
+
         position.amount = 0;
         position.rewardDebt = 0;
-        position.entry = 0;
+        _updateEntry(pid, amount, positionId);
+        _updateAverageEntry(pid, amount, Kind.WITHDRAW);
 
         IRewarder _rewarder = rewarder[pid];
         if (address(_rewarder) != address(0)) {


### PR DESCRIPTION
- Removed support for fee on transfer tokens.

- Cleaned up harvest and withdraw related functions.
    - In deposit, `updateAverageEntry/updateEntry` **FIRST, THEN** `position.amount +`, `position.rewardDebt+`. This is so that the weight calculations that happen inside `updateEntry` don't include the newly deposited `amount` within the total `position.amount`
    - In withdraw, `position.amount -`, `position.rewardDebt-` **FIRST, THEN** `updateAverageEntry/updateEntry`
    - Basically mirrored them.
    - Also in `emergencyWithdraw`, decided to call `updateEntry` after emptying out the position as that would reset the position's `entry` to `timestamp`.

Took slight business logic liberties for what looked to be consistent behavior. Hopefully not breaking anything!