### PR TITLE
Switch from Ownable to AccessControlEnumerable.

### DIFF
--- a/contracts/Reliquary.sol
+++ b/contracts/Reliquary.sol
@@ -47,7 +47,7 @@ contract Reliquary is Relic, AccessControlEnumerable, Multicall, ReentrancyGuard
     /**
      * @notice Access control roles.
      */
-    bytes32 public constant GOVERNANCE = keccak256("GOVERNANCE");
+    bytes32 public constant OPERATOR = keccak256("OPERATOR");
 
     // TODO tess3rac7 is there a better term than PositionInfo? RelicInfo?
     /*
@@ -219,7 +219,7 @@ contract Reliquary is Relic, AccessControlEnumerable, Multicall, ReentrancyGuard
         IRewarder _rewarder,
         ICurve curve,
         string memory name
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    ) public onlyRole(OPERATOR) {
         require(!hasBeenAdded[address(_lpToken)], "this token has already been added");
         require(_lpToken != OATH, "same token");
 
@@ -260,7 +260,7 @@ contract Reliquary is Relic, AccessControlEnumerable, Multicall, ReentrancyGuard
         ICurve curve,
         string memory name,
         bool overwriteRewarder
-    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    ) public onlyRole(OPERATOR) {
         require(pid < poolInfo.length, "set: pool does not exist");
         require(address(curve) != address(0), "invalid curve address");
 

--- a/src/Reliquary.js
+++ b/src/Reliquary.js
@@ -1,25 +1,25 @@
 function debug(arguments) {
   let argumentTypes;
-  for(let i=0; i<arguments.length; i++) {
+  for (let i = 0; i < arguments.length; i++) {
     argumentTypes.push(typeof arguments[i]);
   }
   return argumentTypes;
 }
 
 async function deployChef(oathAddress, nftDescriptorAddress) {
-  let Reliquary = await ethers.getContractFactory("Reliquary");
+  let Reliquary = await ethers.getContractFactory('Reliquary');
   let chef = await Reliquary.deploy(oathAddress, nftDescriptorAddress);
   return chef;
 }
 
 async function deployDescriptor() {
-  let NFTDescriptor = await ethers.getContractFactory("NFTDescriptor");
+  let NFTDescriptor = await ethers.getContractFactory('NFTDescriptor');
   let descriptor = await NFTDescriptor.deploy();
   return descriptor;
 }
 
 async function returnChef(chefAddress) {
-  let Reliquary = await ethers.getContractFactory("Reliquary");
+  let Reliquary = await ethers.getContractFactory('Reliquary');
   let chef = await Reliquary.attach(chefAddress);
   return chef;
 }
@@ -28,19 +28,19 @@ async function getGlobalInfo(chefAddress) {
   let chef = await returnChef(chefAddress);
   let globalInfo = {
     totalAllocPoint: await chef.totalAllocPoint(),
-    chefToken: await chef.OATH()
-  }
+    chefToken: await chef.OATH(),
+  };
   return globalInfo;
 }
 
 async function deployRewarder(multiplier, token, chefAddress) {
-  let Rewarder = await ethers.getContractFactory("RewarderMock");
+  let Rewarder = await ethers.getContractFactory('RewarderMock');
   let rewarder = await Rewarder.deploy(multiplier, token, chefAddress);
   return rewarder;
 }
 
 async function deployCurve() {
-  let Curve = await ethers.getContractFactory("EighthRoot");
+  let Curve = await ethers.getContractFactory('EighthRoot');
   let curve = await Curve.deploy();
   return curve;
 }
@@ -49,12 +49,12 @@ async function viewPoolInfo(chefAddress, pid) {
   let chef = await returnChef(chefAddress);
   let poolInfo = await chef.poolInfo(pid);
   let obj = {
-    "accOathPerShare": poolInfo[0].toString(),
-    "lastRewardTime": poolInfo[1].toString(),
-    "allocPoint": poolInfo[2].toString(),
-    "averageEntry": poolInfo[3].toString(),
-    "curveAddress": poolInfo[4]
-  }
+    accOathPerShare: poolInfo[0].toString(),
+    lastRewardTime: poolInfo[1].toString(),
+    allocPoint: poolInfo[2].toString(),
+    averageEntry: poolInfo[3].toString(),
+    curveAddress: poolInfo[4],
+  };
   return obj;
 }
 
@@ -74,10 +74,10 @@ async function getPositionInfo(chefAddress, positionId) {
   let chef = await returnChef(chefAddress);
   let userInfo = await chef.positionForId(positionId);
   return {
-    "amount": userInfo[0].toString(),
-    "rewardDebt": userInfo[1].toString(),
-    "entry": userInfo[2].toString(),
-    "poolId": userInfo[3].toString()
+    amount: userInfo[0].toString(),
+    rewardDebt: userInfo[1].toString(),
+    entry: userInfo[2].toString(),
+    poolId: userInfo[3].toString(),
   };
 }
 
@@ -87,9 +87,9 @@ async function getPoolCount(chefAddress) {
   return poolLength;
 }
 
-async function addPool(chefAddress, allocPoint, lpToken, rewarder, curve, name) {
+async function addPool(operator, chefAddress, allocPoint, lpToken, rewarder, curve, name) {
   let chef = await returnChef(chefAddress);
-  let tx = await chef.addPool(allocPoint, lpToken, rewarder, curve, name);
+  let tx = await chef.connect(operator).addPool(allocPoint, lpToken, rewarder, curve, name);
   let receipt = await tx.wait();
   return receipt;
 }
@@ -109,7 +109,7 @@ async function pendingOath(chefAddress, positionId) {
 
 async function massUpdatePools(chefAddress, pids) {
   let chef = await returnChef(chefAddress);
-  let tx = await chef.massUpdatePools(pids)
+  let tx = await chef.massUpdatePools(pids);
   let receipt = await tx.wait();
   return receipt;
 }
@@ -215,5 +215,5 @@ module.exports = {
   harvest,
   withdrawAndHarvest,
   emergencyWithdraw,
-  curved
-}
+  curved,
+};


### PR DESCRIPTION
DEFAULT_ADMIN_ROLE == super user. Deployer (presumably our multisig--but if not, multisig can be added to this role by deployer later) will get this role. Can add/remove people from all roles.

OPERATOR == allowed to add pools and modify existing pool properties.

Tests have been updated to include a new signer for operator. I also ran prettier on the test files.

~This is just a 1:1 PR whereby `DEFAULT_ADMIN_ROLE` is equivalent to `OWNER`. I added a `GOVERNANCE` role to demonstrate what adding new roles would look like (although it's currently not used anywhere).~

~Functions included with [AccessControlEnumerable](https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControlEnumerable) pretty much take care of all the role administration. We just now have to add roles we want, and enforce them on functions as we see fit.~

~I feel this would go hand-in-hand very powerfully with a UUPS proxy as that would allow us to deploy upgrades with modified roles (roles are constants, not storage) and seamlessly update the capabilities of each role. We can make it so that only `GOVERNANCE` or some other appropriate role is allowed to do the actual upgrade.~

Here are some more examples of how we use `AccessControlEnumerable` in our strategy contracts:

### Ex 1

```solidity
    /**
     * @dev Updates the current strategistRemitter.
     *      If there is only one strategist this function may be called by
     *      that strategist. However if there are multiple strategists
     *      this function may only be called by the STRATEGIST_MULTISIG role.
     */
    function updateStrategistRemitter(address _newStrategistRemitter) external {
        if (getRoleMemberCount(STRATEGIST) == 1) {
            _checkRole(STRATEGIST, msg.sender);
        } else {
            _checkRole(STRATEGIST_MULTISIG, msg.sender);
        }

        require(_newStrategistRemitter != address(0), "!0");
        strategistRemitter = _newStrategistRemitter;
        emit StrategistRemitterUpdated(_newStrategistRemitter);
    }
```

### Ex 2

```solidity
    /**
     * @dev Only strategist or owner can edit the log cadence.
     */
    function updateHarvestLogCadence(uint256 _newCadenceInSeconds) external {
        _onlyStrategistOrOwner();
        harvestLogCadence = _newCadenceInSeconds;
    }

    /**
     * @dev Only allow access to strategist or owner
     */
    function _onlyStrategistOrOwner() internal view {
        require(hasRole(STRATEGIST, msg.sender) || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not authorized");
    }
```