### PR TITLE
Add view function to query current level of relic

### DIFF
--- a/contracts/Reliquary.sol
+++ b/contracts/Reliquary.sol
@@ -296,6 +296,27 @@ contract Reliquary is IReliquary, ERC721Burnable, ERC721Enumerable, AccessContro
     }
 
     /*
+     + @notice View function to see current level without updating position
+     + @param relicId ID of the position.
+     + @return current level for given position
+    */
+    function currentLevel(uint relicId) public view override returns (uint) {
+        PositionInfo storage position = positionForId[relicId];
+        LevelInfo storage levelInfo = levels[position.poolId];
+        uint length = levelInfo.requiredMaturity.length;
+        if (length == 1) {
+            return 0;
+        }
+
+        uint maturity = block.timestamp - position.entry;
+        for (uint newLevel = length - 1; true; newLevel = _uncheckedDec(newLevel)) {
+            if (maturity >= levelInfo.requiredMaturity[newLevel]) {
+                return newLevel;
+            }
+        }
+    }
+
+    /*
      + @notice Update reward variables for all pools. Be careful of gas spending!
      + @param pids Pool IDs of all to be updated. Make sure to update all active pools.
     */

--- a/contracts/interfaces/IReliquary.sol
+++ b/contracts/interfaces/IReliquary.sol
@@ -75,6 +75,7 @@ interface IReliquary is IERC721Enumerable {
         bool overwriteRewarder
     ) external;
   function pendingOath(uint relicId) external view returns (uint pending);
+  function currentLevel(uint relicId) external view returns (uint);
   function massUpdatePools(uint[] calldata pids) external;
   function updatePool(uint pid) external;
   function createRelicAndDeposit(

--- a/test/foundry/Reliquary.t.sol
+++ b/test/foundry/Reliquary.t.sol
@@ -105,6 +105,20 @@ contract ReliquaryTest is ERC721Holder, Test {
         assertApproxEqAbs(reliquary.pendingOath(relicId), time * 1e17, 1e16);
     }
 
+    function testCurrentLevel(uint maturity) public {
+        vm.assume(maturity < 500 days);
+        uint relicId = reliquary.createRelicAndDeposit(address(this), 0, testToken.balanceOf(address(this)));
+        skip(maturity);
+        uint expectedLevel;
+        for (uint newLevel = requiredMaturity.length - 1; true; newLevel-- ) {
+            if (maturity >= requiredMaturity[newLevel]) {
+                expectedLevel = newLevel;
+                break;
+            }
+        }
+        assertEq(reliquary.currentLevel(relicId), expectedLevel);
+    }
+
     function testMassUpdatePools() public {
         skip(1);
         uint[] memory pools = new uint[](1);


### PR DESCRIPTION
Currently, a relic position could be stale if the position has not been updated in a while. To use the level for snapshot voting or other purposes, there is a need to get the current level of a relic without updating the position. One could do the math on the consumer side but this utilty function would make this easier.

Think your nft descriptor has the same problem, the level stays stale as long as the position is not updated