### PR TITLE
Prevent shift & merge that would extend receiver maturity

### DIFF
--- a/contracts/Reliquary.sol
+++ b/contracts/Reliquary.sol
@@ -501,6 +501,10 @@ contract Reliquary is
 
         vars.fromAmount = fromPosition.amount;
         vars.toAmount = toPosition.amount;
+
+        // Prevent shifts that would extend the maturity of the receiving Relic.
+        if (toPosition.entry < fromPosition.entry) revert InvalidShift();
+
         toPosition.entry = (vars.fromAmount * fromPosition.entry + vars.toAmount * toPosition.entry)
             / (vars.fromAmount + vars.toAmount);
 
@@ -552,6 +556,10 @@ contract Reliquary is
         uint toAmount = toPosition.amount;
         uint newToAmount = toAmount + fromAmount;
         if (newToAmount == 0) revert MergingEmptyRelics();
+
+        // Prevent shifts that would extend the maturity of the receiving Relic.
+        if (toPosition.entry < fromPosition.entry) revert InvalidShift();
+
         toPosition.entry = (fromAmount * fromPosition.entry + toAmount * toPosition.entry) / newToAmount;
 
         toPosition.amount = newToAmount;

--- a/contracts/Reliquary.sol
+++ b/contracts/Reliquary.sol
@@ -92,7 +92,7 @@ contract Reliquary is
     error MaxEmissionRateExceeded();
     error NotApprovedOrOwner();
     error PartialWithdrawalsDisabled();
-    error InvalidShift();
+    error InvalidMaturityChange();
 
     /**
      * @dev Constructs and initializes the contract.
@@ -504,7 +504,7 @@ contract Reliquary is
         vars.toAmount = toPosition.amount;
 
         // Prevent shifts that would extend the maturity of the receiving Relic.
-        if (toPosition.entry < fromPosition.entry) revert InvalidShift();
+        if (toPosition.entry < fromPosition.entry) revert InvalidMaturityChange();
 
         toPosition.entry = (vars.fromAmount * fromPosition.entry + vars.toAmount * toPosition.entry)
             / (vars.fromAmount + vars.toAmount);
@@ -559,7 +559,7 @@ contract Reliquary is
         if (newToAmount == 0) revert MergingEmptyRelics();
 
         // Prevent shifts that would extend the maturity of the receiving Relic.
-        if (toPosition.entry < fromPosition.entry) revert InvalidShift();
+        if (toPosition.entry < fromPosition.entry) revert InvalidMaturityChange();
 
         toPosition.entry = (fromAmount * fromPosition.entry + toAmount * toPosition.entry) / newToAmount;
 

--- a/contracts/Reliquary.sol
+++ b/contracts/Reliquary.sol
@@ -92,6 +92,7 @@ contract Reliquary is
     error MaxEmissionRateExceeded();
     error NotApprovedOrOwner();
     error PartialWithdrawalsDisabled();
+    error InvalidShift();
 
     /**
      * @dev Constructs and initializes the contract.


### PR DESCRIPTION
Adds a check to both the `split` & `merge` functions that would cause the receiver's maturity to be extended.

Includes a test to verify that this reverts appropriately.